### PR TITLE
Allow the use of arguments for cargo bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ harness = false
 [dev-dependencies]
 criterion = "0.3.6"
 
+[lib]
+bench = false


### PR DESCRIPTION
I wanted to try some CLI arguments out and I found that I could not.
Then I found this documentation, which is what this commit applies:

https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>