### PR TITLE
Use slightly smaller numbers for benchmarks

### DIFF
--- a/benches/all.rs
+++ b/benches/all.rs
@@ -7,9 +7,10 @@ use primes::{
 };
 
 // The largest prime number we will search for for eratosthenes-based algorithms.
-const LARGEST_PRIME_TO_SEARCH: u64 = 9999991;
+const LARGEST_PRIME_TO_SEARCH: u64 = 821641;
+
 // The index of LARGEST_PRIME_TO_SEARCH in an array of prime numbers.
-const LARGEST_PRIME_INDEX: usize = 664579;
+const LARGEST_PRIME_INDEX: usize = 65536;
 
 fn live_first_primes(c: &mut Criterion) {
     c.bench_function("live_first_primes", |b| {
@@ -43,5 +44,11 @@ fn test_division(c: &mut Criterion) {
     });
 }
 
-criterion_group!(all, live_first_primes, test_division, sieve_og, sieve_skip_2);
+criterion_group!(
+    all,
+    live_first_primes,
+    test_division,
+    sieve_og,
+    sieve_skip_2
+);
 criterion_main!(all);


### PR DESCRIPTION
**This commit**
* Reduce LARGEST_PRIME_TO_SEARCH to 821641.
* Reduce LARGEST_PRIME_INDEX to 65536.

**Why?**
So that benchmarks run fast enough for a live demo.